### PR TITLE
[PR] Codecov fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,6 @@ jobs:
     - name: Run Tests
       run: mix coveralls.json
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
fixes the Codecov failing.

According to https://github.com/codecov/codecov-action#breaking-changes, with the new `v4`, tokenless uploads will cease to work.